### PR TITLE
Fix issue that prevented 404 from being sent in GET requests with key

### DIFF
--- a/src/Classes/WorkbookWebController.cls
+++ b/src/Classes/WorkbookWebController.cls
@@ -90,9 +90,10 @@ Private Function IWebController_ProcessRequest(request As HttpRequest) As HttpRe
             
             response.Body = getValue.ToJson()
             
-            If TypeName(value) = "JsonValue" Then
+            ' this is a null value check in disguise
+            If TypeName(getValue) = "JsonValue" Then
                 response.StatusCode = 404
-            Else
+            Else ' type is JsonObject
                 response.StatusCode = 200
             End If
             


### PR DESCRIPTION
Hi! You haven't responded to my other Pull Requests yet. If you think they aren't good, you can just say so. I admit I don't know the "right way" to do things in VBA, but I want to help! This change is really simple! The variable `value` wasn't declared in that scope, so the TypeName always evaluated as "Empty". It was clear that `getValue` was intended.