### PR TITLE
Provide index file array for static file server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ Connection: close
 
 No need to spin up a cloud server or function-as-a-service provider, implement rich server side logic right in Microsoft Excel using the built-in tools you already know and love. Using Microsoft Excel's immersive charting, you can gather even deeper insights from your data. 
 
-##### A note about static files
-Webxcel has a fully capable static file server, with the server root located in the directory of `Webxcel.xlsm`. However, it doesn't automatically locate your index.html. This is a [known issue](https://github.com/michaelneu/webxcel/issues/14) and will be updated in a future release. Your app will work as normal if you explicitly navigate to `/index.html`.
 
 #### Scalable
 

--- a/src/Classes/FileInfo.cls
+++ b/src/Classes/FileInfo.cls
@@ -39,7 +39,7 @@ Public Property Get MimeType() As String
         Case "json", "xml"
             MimeType = "application/" & ext
             
-        Case "html", "txt"
+        Case "html", "htm", "txt"
             MimeType = "text/html"
             
         Case "png", "jpg", "jpeg", "gif"

--- a/src/Classes/FileSystemWebController.cls
+++ b/src/Classes/FileSystemWebController.cls
@@ -10,10 +10,15 @@ Attribute VB_Exposed = False
 Implements IWebController
 
 Private m_directory As String
+Private m_indexFiles As Collection
 
 
 Private Sub Class_Initialize()
     m_directory = ActiveWorkbook.Path
+    
+    Set m_indexFiles = New Collection
+    m_indexFiles.Add "index.html"
+    m_indexFiles.Add "index.htm"
 End Sub
 
 
@@ -27,6 +32,11 @@ Public Property Let Directory(val As String)
     val = StringExtensions.TrimRight(val, "\")
     
     m_directory = val
+End Property
+
+
+Public Property Get IndexFiles() As Collection
+    Set IndexFiles = m_indexFiles
 End Property
 
 
@@ -51,6 +61,27 @@ Private Function IWebController_ProcessRequest(request As HttpRequest) As HttpRe
         response.StatusCode = 200
         response.Headers.AddHeader "Content-Type", file.MimeType
         response.Body = file.ReadString
+    ElseIf m_indexFiles.Count > 0 Then
+        Dim foundIndexFile As Boolean
+        foundIndexFile = False
+        
+        For Each indexFile In m_indexFiles
+            Set file = New FileInfo
+            file.Initialize PathJoin(filename, indexFile)
+
+            If file.Exists Then
+                response.StatusCode = 200
+                response.Headers.AddHeader "Content-Type", file.MimeType
+                response.Body = file.ReadString
+                
+                foundIndexFile = True
+                Exit For
+            End If
+        Next
+
+        If foundIndexFile = False Then
+            response.StatusCode = 404
+        End If
     Else
         response.StatusCode = 404
     End If

--- a/src/Classes/HttpServer.cls
+++ b/src/Classes/HttpServer.cls
@@ -12,6 +12,8 @@ Private m_controllers As WebControllerCollection
 
 
 Private Sub Class_Initialize()
+    InitializeHttpStatusDictionary
+
     Set m_tcpServer = New TcpServer
     Set m_controllers = New WebControllerCollection
 End Sub

--- a/src/Modules/Main.bas
+++ b/src/Modules/Main.bas
@@ -1,6 +1,5 @@
 Attribute VB_Name = "Main"
 Public Sub Main()
-    InitializeHttpStatusDictionary
     Dim server As HttpServer
     Set server = New HttpServer
     

--- a/src/Modules/PathExtensions.bas
+++ b/src/Modules/PathExtensions.bas
@@ -1,0 +1,29 @@
+Attribute VB_Name = "PathExtensions"
+Public Function PathJoin(ParamArray pathParts() As Variant) As String
+    If IsEmpty(pathParts) Then
+        Exit Function
+    End If
+
+    Dim partIndex As Integer
+    Dim pathPart As String
+    Dim joinedPath As String
+    joinedPath = ""
+
+    For partIndex = LBound(pathParts) To UBound(pathParts) - 1
+        pathPart = pathParts(partIndex)
+        pathPart = TrimRight(pathPart, "/")
+        pathPart = TrimRight(pathPart, "\")
+        
+        joinedPath = joinedPath & pathPart & "/"
+    Next
+
+    pathPart = pathParts(UBound(pathParts))
+
+    If UBound(pathParts) > 1 Then
+        pathPart = TrimLeft(pathPart, "/")
+        pathPart = TrimLeft(pathPart, "\")
+    End If
+
+    joinedPath = joinedPath & pathPart
+    PathJoin = joinedPath
+End Function

--- a/src/Modules/StringExtensions.bas
+++ b/src/Modules/StringExtensions.bas
@@ -25,7 +25,7 @@ Public Function TrimRight(text As String, c As String) As String
     
     Do While textLength > 0
         Dim lastCharacter As String
-        lastCharacter = Left(text, 1)
+        lastCharacter = Right(text, 1)
         
         If lastCharacter <> c Then
             Exit Do
@@ -57,3 +57,4 @@ End Function
 Public Function CharAt(ByVal text As String, ByVal index As Integer) As String
     CharAt = Mid(text, index, 1)
 End Function
+


### PR DESCRIPTION
Fixes #14.

When creating a `FileSystemWebController`, you can now use the `IndexFiles` property to add custom index files. By default, *index.html* and *index.htm* are used:

```vba
Public Sub Main()
    Dim server As HttpServer
    Set server = New HttpServer

    Dim controller As FileSystemWebController
    Set controller = New FileSystemWebController

    controller.IndexFiles.Add "myindex.html"
    
    server.Controllers.AddController controller
    server.Serve 8080
End Sub
```